### PR TITLE
fixed deprecation warning for context_processors

### DIFF
--- a/debugtools/templatetags/debugtools_tags.py
+++ b/debugtools/templatetags/debugtools_tags.py
@@ -1,7 +1,10 @@
 """
 Debugging features in in the template.
 """
-from django.core import context_processors
+try: # try do import from new location (django>=1.8)
+    from django.template import context_processors
+except ImportError: # fallback to old location
+    from django.core import context_processors    
 from django.template import Library, Node, Variable, VariableDoesNotExist
 from django.template.defaultfilters import linebreaksbr
 from django.utils import six


### PR DESCRIPTION
Built-in template context processors have been moved to django.template.context_processors in django 1.8